### PR TITLE
Add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Or install it yourself as:
 
     $ gem install ubuntu_unused_kernels
 
+## Requires
+
+Ruby v1.9 or later
+
 ## Usage
 
 ```


### PR DESCRIPTION
I found it didn't work with Ruby 1.8 but did with 1.9.3, so thought it worth adding to the readme.
